### PR TITLE
Change kernel size in pyramic convolutions.

### DIFF
--- a/keras_retinanet/models/retinanet.py
+++ b/keras_retinanet/models/retinanet.py
@@ -59,24 +59,24 @@ def regression_subnet(num_anchors=9, feature_size=256):
 
 def pyramid_features(C3, C4, C5, feature_size=256):
     # upsample C5 to get P5 from the FPN paper
-    P5           = keras.layers.Conv2D(feature_size, (1, 1), strides=1, padding='same', name='P5')(C5)
+    P5           = keras.layers.Conv2D(feature_size, kernel_size=1, strides=1, padding='same', name='P5')(C5)
     P5_upsampled = keras_retinanet.layers.UpsampleLike(name='P5_upsampled')([P5, C4])
 
     # add P5 elementwise to C4
-    P4           = keras.layers.Conv2D(feature_size, (3, 3), strides=1, padding='same', name='C4_reduced')(C4)
+    P4           = keras.layers.Conv2D(feature_size, kernel_size=1, strides=1, padding='same', name='C4_reduced')(C4)
     P4           = keras.layers.Add(name='P4')([P5_upsampled, P4])
     P4_upsampled = keras_retinanet.layers.UpsampleLike(name='P4_upsampled')([P4, C3])
 
     # add P4 elementwise to C3
-    P3 = keras.layers.Conv2D(feature_size, (3, 3), strides=1, padding='same', name='C3_reduced')(C3)
+    P3 = keras.layers.Conv2D(feature_size, kernel_size=1, strides=1, padding='same', name='C3_reduced')(C3)
     P3 = keras.layers.Add(name='P3')([P4_upsampled, P3])
 
     # "P6 is obtained via a 3x3 stride-2 conv on C5"
-    P6 = keras.layers.Conv2D(feature_size, (3, 3), strides=2, padding='same', name='P6')(C5)
+    P6 = keras.layers.Conv2D(feature_size, kernel_size=3, strides=2, padding='same', name='P6')(C5)
 
     # "P7 is computed by applying ReLU followed by a 3x3 stride-2 conv on P6"
     P7 = keras.layers.Activation('relu', name='C6_relu')(P6)
-    P7 = keras.layers.Conv2D(feature_size, (3, 3), strides=2, padding='same', name='P7')(P7)
+    P7 = keras.layers.Conv2D(feature_size, kernel_size=3, strides=2, padding='same', name='P7')(P7)
 
     return P3, P4, P5, P6, P7
 


### PR DESCRIPTION
Modified the convolutional filters dimensions when upsampling and adding for climbing the pyramid features, as proposed in the paper.
When moving from P5 to P4, there is upsampling of P5 and addition of a 1x1 convolution of C4, not a 3x3 convolution. 