### PR TITLE
Add missing conv fpn

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,21 +48,21 @@ Execution time on NVIDIA Pascal Titan X is roughly 55msec for an image of shape 
 ## Results
 
 ### MS COCO
-The MS COCO model can be downloaded [here](https://delftrobotics-my.sharepoint.com/personal/h_gaiser_fizyr_com/_layouts/15/guestaccess.aspx?docid=1d51021426e7147fb89bc534671ae50aa&authkey=AXOvo1KqF_NU8QmP5pP1QUo&e=c2a23915773a4cf7bd3b8fff8bc18803). Results using the `cocoapi` are shown below (note: according to the paper, this configuration should achieve a mAP of 0.34).
+The MS COCO model can be downloaded [here](https://delftrobotics-my.sharepoint.com/personal/h_gaiser_fizyr_com/_layouts/15/guestaccess.aspx?docid=08db522fc87ba48189ca4629377c2646e&authkey=AS3wwMzO1bb9dHBvrMdNJ5s&e=cde447bbbd2d42ad88b5a5d9d623bbfa). Results using the `cocoapi` are shown below (note: according to the paper, this configuration should achieve a mAP of 0.34).
 
 ```
- Average Precision  (AP) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.306
+ Average Precision  (AP) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.304
  Average Precision  (AP) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.485
- Average Precision  (AP) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.323
- Average Precision  (AP) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.131
- Average Precision  (AP) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.336
- Average Precision  (AP) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.439
+ Average Precision  (AP) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.326
+ Average Precision  (AP) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.136
+ Average Precision  (AP) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.337
+ Average Precision  (AP) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.427
  Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=  1 ] = 0.274
- Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets= 10 ] = 0.410
- Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.422
- Average Recall     (AR) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.217
- Average Recall     (AR) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.467
- Average Recall     (AR) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.591
+ Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets= 10 ] = 0.412
+ Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.423
+ Average Recall     (AR) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.220
+ Average Recall     (AR) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.472
+ Average Recall     (AR) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.587
 ```
 
 ## Status

--- a/keras_retinanet/models/retinanet.py
+++ b/keras_retinanet/models/retinanet.py
@@ -96,12 +96,14 @@ def __create_pyramid_features(C3, C4, C5, feature_size=256):
 
     # add P5 elementwise to C4
     P4           = keras.layers.Conv2D(feature_size, kernel_size=1, strides=1, padding='same', name='C4_reduced')(C4)
-    P4           = keras.layers.Add(name='P4')([P5_upsampled, P4])
+    P4           = keras.layers.Add(name='P4_merged')([P5_upsampled, P4])
+    P4           = keras.layers.Conv2D(feature_size, kernel_size=3, strides=1, padding='same', name='P4')(P4)
     P4_upsampled = keras_retinanet.layers.UpsampleLike(name='P4_upsampled')([P4, C3])
 
     # add P4 elementwise to C3
     P3 = keras.layers.Conv2D(feature_size, kernel_size=1, strides=1, padding='same', name='C3_reduced')(C3)
-    P3 = keras.layers.Add(name='P3')([P4_upsampled, P3])
+    P3 = keras.layers.Add(name='P3_merged')([P4_upsampled, P3])
+    P3 = keras.layers.Conv2D(feature_size, kernel_size=3, strides=1, padding='same', name='P3')(P3)
 
     # "P6 is obtained via a 3x3 stride-2 conv on C5"
     P6 = keras.layers.Conv2D(feature_size, kernel_size=3, strides=2, padding='same', name='P6')(C5)


### PR DESCRIPTION
As discussed in [this](https://github.com/delftrobotics/keras-retinanet/issues/35) issue, the architecture was missing two conv layers. This PR adds those layers and a new download link to the retinanet COCO model.